### PR TITLE
Implement skip condition based on python expressions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 sudo: false
 language: python
 python:
-- '2.7'
 - '3.6'
-- pypy
 install:
 - pip install codecov
 - pip install tox

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,12 @@ Changelog
 1.1.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- implement python based commands in ``pytest-play`` and
+  deprecates ``play_python``.
+  So this feature is a drop-in replacement for the
+  ``play-python`` plugin.
+
+  You should no more install ``play_python`` since now.
 
 
 1.1.0 (2018-01-16)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,12 @@ Changelog
 
 - update documentation
 
+- deprecate selenium commands (they will be implemented
+  on a separate plugin and dropped in
+  ``pytest-play`` >= 2.0.0). All your previous scripts
+  will work fine, this warning is just for people
+  directly importing the provider for some reason.
+
 
 1.1.0 (2018-01-16)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,9 @@ Changelog
   will work fine, this warning is just for people
   directly importing the provider for some reason.
 
+- implement skip conditions. You can omit the execution of
+  any command evaluating a Python based skip condition
+
 
 1.1.0 (2018-01-16)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Changelog
 
   You should no more install ``play_python`` since now.
 
+- update documentation
+
 
 1.1.0 (2018-01-16)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -263,6 +263,20 @@ repeat the group of commands for 10 times::
     })
 
 
+Conditional commands
+--------------------
+
+You can skip any command evaluating a Python based skip condition
+like the following::
+
+    {
+      "provider": "include",
+      "type": "include",
+      "path": "/some-path/assertions.json",
+      "skip_condition": "variables['cassandra_assertions'] is True"
+    }
+
+
 Browser based commands
 ======================
 

--- a/pytest_play/providers/__init__.py
+++ b/pytest_play/providers/__init__.py
@@ -1,0 +1,4 @@
+from .base import BaseProvider
+from .include import IncludeProvider
+from .selenium import SplinterCommandProvider
+from .python import PythonProvider

--- a/pytest_play/providers/base.py
+++ b/pytest_play/providers/base.py
@@ -1,0 +1,7 @@
+
+
+class BaseProvider(object):
+    """ Base command provider  """
+
+    def __init__(self, engine):
+        self.engine = engine

--- a/pytest_play/providers/include.py
+++ b/pytest_play/providers/include.py
@@ -1,0 +1,13 @@
+from . import BaseProvider
+
+
+class IncludeProvider(BaseProvider):
+    """ PlayEngine wrapper """
+
+    def command_include(self, command, **kwargs):
+        """ Include scenario """
+        file_path = command['path']
+        data = self.engine.get_file_contents(file_path)
+        self.engine.execute(
+            self.engine.parametrizer.parametrize(data)
+        )

--- a/pytest_play/providers/python.py
+++ b/pytest_play/providers/python.py
@@ -1,0 +1,127 @@
+import json
+import re
+from time import (
+    sleep,
+    time,
+)
+from RestrictedPython import RestrictionCapableEval
+from pytest_play.providers import BaseProvider
+import datetime
+
+
+class TimeoutException(Exception):
+    """ Timeout exception """
+
+
+class PythonProvider(BaseProvider):
+    """ Python command provider """
+
+    def _get_context(self, extra_context):
+        context = {
+            'variables': self.engine.variables,
+            'len': len,
+            'list': list,
+            'match': re.match,
+            'datetime': datetime,
+            'loads': json.loads,
+            'dumps': json.dumps,
+            'filter': filter,
+            'map': map,
+            }
+        context.update(extra_context)
+        return context
+
+    def command_assert(self, command, **kwargs):
+        """ Make an assertion based on a command containing
+            a python expression
+        """
+        expression = command.get('expression', None)
+        if expression:
+            context = self._get_context(kwargs)
+            assert self._exec(
+                expression,
+                context,
+            )
+
+    def command_store_variable(self, command, **kwargs):
+        """ Store a variable based on a command containing a
+            python expression
+        """
+        expression = command['expression']
+        name = command['name']
+        context = self._get_context(kwargs)
+        self.engine.variables[name] = self._exec(
+            expression,
+            context,
+        )
+
+    def command_exec(self, command, **kwargs):
+        """ Exec and return an expression
+        """
+        expression = command['expression']
+        context = self._get_context(kwargs)
+        return self._exec(
+            expression,
+            context,
+        )
+
+    def command_sleep(self, command, **kwargs):
+        """ Exec and return an expression
+        """
+        wait_time = int(command['seconds'])
+        sleep(wait_time)
+
+    def command_wait_until(self, command, **kwargs):
+        """ Wait until an expression is not False
+        """
+        timeout = command.get('timeout', 10)
+        poll = command.get('poll', 0.1)
+        expression = command['expression']
+
+        end_time = time() + timeout
+        while True:
+            for sub_cmd in command['sub_commands']:
+                self.engine.execute_command(sub_cmd)
+            if self.engine.execute_command({
+                    'provider': 'python',
+                    'type': 'exec',
+                    'expression': expression,
+                    }):
+                return
+            if timeout:
+                if time() > end_time:
+                    break
+            if poll:
+                sleep(poll)
+        raise TimeoutException(command, timeout)
+
+    def command_wait_until_not(self, command, **kwargs):
+        """ Wait until an expression is False
+        """
+        timeout = command.get('timeout', 10)
+        poll = command.get('poll', 0.1)
+        expression = command['expression']
+
+        end_time = time() + timeout
+        while True:
+            for sub_cmd in command['sub_commands']:
+                self.engine.execute_command(sub_cmd)
+            if not self.engine.execute_command({
+                    'provider': 'python',
+                    'type': 'exec',
+                    'expression': expression,
+                    }):
+                return
+            if timeout:
+                if time() > end_time:
+                    break
+            if poll:
+                sleep(poll)
+        raise TimeoutException(command, timeout)
+
+    def _exec(self, expression, context):
+        """ Evaluate a python expression against a given context
+        """
+
+        context = context.copy()
+        return RestrictionCapableEval(expression).eval(context)

--- a/pytest_play/providers/selenium.py
+++ b/pytest_play/providers/selenium.py
@@ -2,6 +2,12 @@ import re
 from time import sleep
 from selenium.webdriver.common.keys import Keys
 from . import BaseProvider
+import warnings
+
+
+warnings.warn(
+    "This provider will be moved to a separate package in 2.0.0",
+    DeprecationWarning)
 
 
 class SplinterCommandProvider(BaseProvider):

--- a/pytest_play/providers/selenium.py
+++ b/pytest_play/providers/selenium.py
@@ -1,25 +1,7 @@
 import re
 from time import sleep
 from selenium.webdriver.common.keys import Keys
-
-
-class BaseProvider(object):
-    """ Base command provider  """
-
-    def __init__(self, engine):
-        self.engine = engine
-
-
-class IncludeProvider(BaseProvider):
-    """ PlayEngine wrapper """
-
-    def command_include(self, command, **kwargs):
-        """ Include scenario """
-        file_path = command['path']
-        data = self.engine.get_file_contents(file_path)
-        self.engine.execute(
-            self.engine.parametrizer.parametrize(data)
-        )
+from . import BaseProvider
 
 
 class SplinterCommandProvider(BaseProvider):

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ install_requires = [
     'pytest-variables[yaml]',
     'pytest-pypom-navigation',
     'pytest-splinter',
-    'zope.interface'
+    'zope.interface',
+    'RestrictedPython>=4.0.b2',
 ]
 
 tests_require = [
@@ -69,6 +70,7 @@ setup(
         'playcommands': [
             'default = pytest_play.providers:SplinterCommandProvider',
             'include = pytest_play.providers:IncludeProvider',
+            'python = pytest_play.providers:PythonProvider',
         ],
         'pytest11': [
             'pytest-play = pytest_play.plugin',

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -273,3 +273,34 @@ def test_wait_until_not_countdown_timeout(play_json):
     now_now = datetime.now()
     expected_date = now + timedelta(seconds=1.3)
     assert now_now >= expected_date
+
+
+def test_skip_condition(play_json):
+    play_json.variables = {'foo': 'baz'}
+    play_json.execute_command({
+        'provider': 'python',
+        'type': 'assert',
+        'expression': '200 == 404',
+        'skip_condition': '"$foo" == "baz"'
+    })
+
+
+def test_skip_condition_str(play_json):
+    play_json.variables = {'foo': 'baz'}
+    play_json.execute_command("""{
+        "provider": "python",
+        "type": "assert",
+        "expression": "200 == 404",
+        "skip_condition": "'$foo' == 'baz'"
+    }""")
+
+
+def test_skip_condition_false(play_json):
+    play_json.variables = {'foo': 'baz'}
+    with pytest.raises(AssertionError):
+        play_json.execute_command({
+            'provider': 'python',
+            'type': 'assert',
+            'expression': '200 == 404',
+            'skip_condition': '"$foo" != "baz"'
+        })

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests for `pytest_play` package."""
+
+import pytest
+
+
+@pytest.fixture(scope='session')
+def variables():
+    return {'skins': {'skin1': {'base_url': 'http://', 'credentials': {}}}}
+
+
+@pytest.mark.parametrize('expression', [
+    '200 == 200',
+    '200 != 404 and 10>0',
+    'variables["foo"] == "baz"',
+    '"foo" in variables',
+    'len([1]) == 1',
+    '[1][0] == 1',
+    'len(list(variables.items())) == 1',
+    'variables["foo"].upper() == "BAZ"',
+    'match(r"^([0-9]*)-data", "123-data")',
+    'match(r"^([0-9]*)-data", "123-data").group(1) == "123"',
+    'datetime.datetime.now() > (datetime.datetime.now() - '
+    'datetime.timedelta(seconds=1))'
+])
+def test_assertion(expression):
+    import mock
+    mock_engine = mock.MagicMock()
+    mock_engine.variables = {'foo': 'baz'}
+    from pytest_play import providers
+    provider = providers.PythonProvider(mock_engine)
+    assert provider.engine is mock_engine
+    provider.command_assert({
+        'provider': 'python',
+        'type': 'assert',
+        'expression': expression
+    })
+
+
+def test_assertion_ko():
+    import mock
+    mock_engine = mock.MagicMock()
+    mock_engine.variables = {'foo': 'baz'}
+    from pytest_play import providers
+    provider = providers.PythonProvider(mock_engine)
+    assert provider.engine is mock_engine
+    with pytest.raises(AssertionError):
+        provider.command_assert({
+            'provider': 'python',
+            'type': 'assert',
+            'expression': '200 == 404'
+        })
+
+
+@pytest.mark.parametrize('expression', [
+    'open("/etc/passwd", "r")',
+    'open',
+    'import os',
+    '__file__',
+    '__file__',
+    '__builtins__.__dict__["bytes"]',
+    '__builtins__.__dict__["bytes"] = "pluto"',
+    'prova = lambda: 1',
+    'os = 1',
+])
+def test_assertion_bad(expression):
+    import mock
+    mock_engine = mock.MagicMock()
+    mock_engine.variables = {'foo': 'baz'}
+    from pytest_play import providers
+    provider = providers.PythonProvider(mock_engine)
+    assert provider.engine is mock_engine
+    with pytest.raises(Exception):
+        provider.command_assert({
+            'provider': 'python',
+            'type': 'assert',
+            'expression': expression
+        })
+
+
+def test_store_variable():
+    import mock
+    mock_engine = mock.MagicMock()
+    mock_engine.variables = {'foo': 'baz'}
+    from pytest_play import providers
+    provider = providers.PythonProvider(mock_engine)
+    assert provider.engine is mock_engine
+    provider.command_store_variable({
+        'provider': 'python',
+        'type': 'store_variable',
+        'expression': '1+1',
+        'name': 'sum2'
+    })
+    assert 'sum2' in mock_engine.variables
+    assert mock_engine.variables['foo'] == 'baz'
+    assert mock_engine.variables['sum2'] == 2
+
+
+def test_exec():
+    import mock
+    mock_engine = mock.MagicMock()
+    mock_engine.variables = {'foo': 'baz'}
+    from pytest_play import providers
+    provider = providers.PythonProvider(mock_engine)
+    assert provider.engine is mock_engine
+    assert provider.command_exec({
+        'provider': 'python',
+        'type': 'exec',
+        'expression': '1+1',
+        }) == 2
+
+
+@pytest.mark.parametrize('expression', [
+    'variable == 200',
+])
+def test_assertion_kwargs(expression):
+    import mock
+    mock_engine = mock.MagicMock()
+    mock_engine.variables = {'foo': 'baz'}
+    assert 'variable' not in mock_engine.variables
+    from pytest_play import providers
+    provider = providers.PythonProvider(mock_engine)
+    assert provider.engine is mock_engine
+    provider.command_assert({
+        'provider': 'python',
+        'type': 'assert',
+        'expression': expression
+        },
+        variable=200)
+    assert 'variable' not in mock_engine.variables
+
+
+def test_sleep():
+    import mock
+    mock_engine = mock.MagicMock()
+    mock_engine.variables = {}
+    from pytest_play import providers
+    provider = providers.PythonProvider(mock_engine)
+    assert provider.engine is mock_engine
+    from datetime import (
+        datetime,
+        timedelta,
+    )
+    now = datetime.now()
+    provider.command_sleep({
+        'provider': 'python',
+        'type': 'sleep',
+        'seconds': 2
+    })
+    now_now = datetime.now()
+    expected_date = now + timedelta(milliseconds=2000)
+    assert now_now >= expected_date
+
+
+def test_wait_until_countdown(play_json):
+    play_json.variables = {'countdown': 10}
+    from datetime import (
+        datetime,
+        timedelta,
+    )
+    now = datetime.now()
+    play_json.execute_command({
+        'provider': 'python',
+        'type': 'wait_until',
+        'expression': 'variables["countdown"] == 0',
+        'timeout': 1.3,
+        'poll': 0.1,
+        'sub_commands': [{
+            'provider': 'python',
+            'type': 'store_variable',
+            'name': 'countdown',
+            'expression': 'variables["countdown"] - 1'
+        }]
+    })
+    now_now = datetime.now()
+    expected_date = now + timedelta(seconds=0.9)
+    assert now_now >= expected_date
+
+
+def test_wait_until_countdown_no_poll(play_json):
+    play_json.variables = {'countdown': 10}
+    play_json.execute_command({
+        'provider': 'python',
+        'type': 'wait_until',
+        'expression': 'variables["countdown"] == 0',
+        'timeout': 0,
+        'poll': 0,
+        'sub_commands': [{
+            'provider': 'python',
+            'type': 'store_variable',
+            'name': 'countdown',
+            'expression': 'variables["countdown"] - 1'
+        }]
+    })
+
+
+def test_wait_until_countdown_timeout(play_json):
+    from pytest_play.providers.python import TimeoutException
+    play_json.variables = {'countdown': 20}
+    from datetime import (
+        datetime,
+        timedelta,
+    )
+    now = datetime.now()
+    with pytest.raises(TimeoutException):
+        play_json.execute_command({
+            'provider': 'python',
+            'type': 'wait_until',
+            'expression': 'variables["countdown"] == 0',
+            'timeout': 1.3,
+            'poll': 0.1,
+            'sub_commands': [{
+                'provider': 'python',
+                'type': 'store_variable',
+                'name': 'countdown',
+                'expression': 'variables["countdown"] - 1'
+            }]
+        })
+    now_now = datetime.now()
+    expected_date = now + timedelta(seconds=1.3)
+    assert now_now >= expected_date
+
+
+def test_wait_until_not_countdown(play_json):
+    play_json.variables = {'countdown': 10}
+    from datetime import (
+        datetime,
+        timedelta,
+    )
+    now = datetime.now()
+    play_json.execute_command({
+        'provider': 'python',
+        'type': 'wait_until_not',
+        'expression': 'variables["countdown"] > 0',
+        'timeout': 1.3,
+        'poll': 0.1,
+        'sub_commands': [{
+            'provider': 'python',
+            'type': 'store_variable',
+            'name': 'countdown',
+            'expression': 'variables["countdown"] - 1'
+        }]
+    })
+    now_now = datetime.now()
+    expected_date = now + timedelta(seconds=0.9)
+    assert now_now >= expected_date
+
+
+def test_wait_until_not_countdown_timeout(play_json):
+    from pytest_play.providers.python import TimeoutException
+    play_json.variables = {'countdown': 20}
+    from datetime import (
+        datetime,
+        timedelta,
+    )
+    now = datetime.now()
+    with pytest.raises(TimeoutException):
+        play_json.execute_command({
+            'provider': 'python',
+            'type': 'wait_until_not',
+            'expression': 'variables["countdown"] > 0',
+            'timeout': 1.3,
+            'poll': 0.1,
+            'sub_commands': [{
+                'provider': 'python',
+                'type': 'store_variable',
+                'name': 'countdown',
+                'expression': 'variables["countdown"] - 1'
+            }]
+        })
+    now_now = datetime.now()
+    expected_date = now + timedelta(seconds=1.3)
+    assert now_now >= expected_date

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py27,py35,py36,pypy,flake8,docs
+envlist = py36,flake8,docs
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
This PR contains:
* include play_python commands directly in pytest-play and deprecates play_python
* implement skip condition based on python expressions
* dropped support for python 2.7. Add yourself python2.7 or pay someone for do it

Side effects:
* loose pypy compatibility due to RestrictedPython package