### PR TITLE
implement optional teardown callbacks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changelog
 
 - documentation improvements
 
+- supports teardown callbacks
+
 
 1.2.0 (2018-01-22)
 ==================

--- a/pytest_play/engine.py
+++ b/pytest_play/engine.py
@@ -35,6 +35,20 @@ class PlayEngine(object):
         self.gsm = component.getGlobalSiteManager()
 
         self.register_plugins()
+        self._teardown = []
+
+    def register_teardown_callback(self, callback):
+        """ Register teardown callback """
+        if callback not in self._teardown:
+            self._teardown.append(callback)
+
+    def teardown(self):
+        """ Teardown """
+        for callback in self._teardown:
+            try:
+                callback()
+            except Exception:
+                pass
 
     def get_file_contents(self, *tokens):
         """ Return file contents """

--- a/pytest_play/plugin.py
+++ b/pytest_play/plugin.py
@@ -28,4 +28,6 @@ def play_json(request, play_engine_class, bdd_vars, variables, skin):
         password_key = "{0}_pwd".format(credential_name)
         context[username_key] = credential_settings['username']
         context[password_key] = credential_settings['password']
-    return play_engine_class(request, context)
+    play_json = play_engine_class(request, context)
+    yield play_json
+    play_json.teardown()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -19,6 +19,19 @@ def test_get_file_contents(play_json, data_base_path):
     play_json.get_file_contents(data_base_path, 'login.json')
 
 
+def test_register_teardown(play_json, data_base_path):
+    assert play_json._teardown == []
+    import mock
+    callback = mock.MagicMock()
+    play_json.register_teardown_callback(callback)
+    play_json.register_teardown_callback(callback)
+    assert callback in play_json._teardown
+    assert len(play_json._teardown) == 1
+    assert not callback.called
+    play_json.teardown()
+    assert callback.assert_called_once_with() is None
+
+
 def test_splinter_executor_parametrizer(dummy_executor):
     assert dummy_executor.parametrizer.parametrize('$foo') == 'bar'
 


### PR DESCRIPTION
some plugins might need to use play_json instance for caching expensive connections (eg: cassandra cluster and session) but the provider is not able to know when shutdown should be called because they don't know it there will be another command sharing that cluster/keyspace.

This PR let some third party plugins to register a callback and pytest-play will invoke it before the fixture will die (scope=function).

Plugins can cache values such as time consuming database connection objects on a play_json instance attribute. By non written convention you can use the provider name as attribute name assuming no one will use such attribute name. In future it might change.